### PR TITLE
Fix/version change ocamlformat

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,1 +1,1 @@
-version=0.26.2
+version=0.27.0

--- a/giflib/gIF.ml
+++ b/giflib/gIF.ml
@@ -479,7 +479,6 @@ let _find_color_fn palette =
   Array.iteri (fun i (r, g, b) -> colors.{r, g, b} <- i) palette;
   function r, g, b -> Bigarray.Array3.get colors r g b
 
-
 (* Z danego obrazka tworzy caly kontener GIF z jedna ramka. Wymaga, by
    obrazek mial palete <= niz 256 kolorow *)
 let from_image img =

--- a/giflib/gIF.mli
+++ b/giflib/gIF.mli
@@ -1,12 +1,12 @@
 (** {1 GIF file}
 
-  The container object for one or more {! Image}.
-*)
+    The container object for one or more {! Image}. *)
 
 type t
 
 val from_file : string -> t
-(** [from_file filename] will load GIF file from the name provided. Will throw exception on error. *)
+(** [from_file filename] will load GIF file from the name provided. Will throw
+    exception on error. *)
 
 val from_image : Image.t -> t
 val to_file : t -> string -> unit
@@ -18,7 +18,9 @@ val image_count : t -> int
 (** Get the number of images in the container GIF *)
 
 val dimensions : t -> int * int
-(** Returns the screen dimensions of the GIF file. Note that individual images may render to a smaller area than
-    the overall dimensions - you should check the offset and dimensions of each image and render it relative to this frame. *)
+(** Returns the screen dimensions of the GIF file. Note that individual images
+    may render to a smaller area than the overall dimensions - you should check
+    the offset and dimensions of each image and render it relative to this
+    frame. *)
 
 exception Error of string

--- a/giflib/image.ml
+++ b/giflib/image.ml
@@ -12,8 +12,8 @@ type t = {
   delay_time : int option;
 }
 
-let v ?offset ?transparent ?delay_time dim palette compressed_image_data lzw_code_size
-    interlaced =
+let v ?offset ?transparent ?delay_time dim palette compressed_image_data
+    lzw_code_size interlaced =
   let width, height = dim in
   let x_offset, y_offset = match offset with None -> (0, 0) | Some x -> x in
   let transparent = match transparent with None -> None | Some x -> x in
@@ -84,7 +84,9 @@ let pixels i =
       let p = !(i.pixels) in
       match Array.length p with
       | 0 ->
-          let decoded_data = Lzw.decode i.compressed_image_data i.lzw_code_size in
+          let decoded_data =
+            Lzw.decode i.compressed_image_data i.lzw_code_size
+          in
           if Bytes.length decoded_data != i.width * i.height then
             failwith
               (Printf.sprintf "too few/many pixels: expected %d got %d"

--- a/giflib/image.mli
+++ b/giflib/image.mli
@@ -1,7 +1,6 @@
 (** {1 GIF image}
 
-  Represents a single image within the GIF file.
-*)
+    Represents a single image within the GIF file. *)
 
 type t
 
@@ -17,8 +16,9 @@ val v :
   t
 
 val dimensions : t -> int * int
-(** The dimensions of the image. Note that this might be smaller than the dimensions of the GIF overall, as animated GIFs
-    can have partial update frames. *)
+(** The dimensions of the image. Note that this might be smaller than the
+    dimensions of the GIF overall, as animated GIFs can have partial update
+    frames. *)
 
 val offset : t -> int * int
 (** The offset of this image within the overall GIF dimensions *)
@@ -33,10 +33,13 @@ val rgb_pixels : t -> (int * int * int) array
 (** The pixels in RGB space of the image *)
 
 val transparent : t -> int option
-(** If specified, the palette entry that should be treated as transparent for this image and not rendered on screen. *)
+(** If specified, the palette entry that should be treated as transparent for
+    this image and not rendered on screen. *)
 
 val delay_time : t -> int option
-(** If specified, the time in 1/100ths of a second that should be delayed after this frame is rendered. *)
+(** If specified, the time in 1/100ths of a second that should be delayed after
+    this frame is rendered. *)
 
 val compressed_image_data : t -> Bytes.t
-(** Get the raw compressed image data. Use `pixels` or `rgb_pixels` to get the uncompressed data. *)
+(** Get the raw compressed image data. Use `pixels` or `rgb_pixels` to get the
+    uncompressed data. *)

--- a/giflib/lzw.ml
+++ b/giflib/lzw.ml
@@ -160,9 +160,9 @@ let make_codes input initial_code_size =
              dlugosc kodu do dlugosci poczatkowej *)
           if new_avail_code >= 0xFFF then
             (code, code_size) :: (clear_code, code_size)
-            :: encode (input_index + initial_code_size) EncDict.empty [ char ]
-                (initial_code_size + 1)
-                (clear_code + 2)
+            :: encode
+                 (input_index + initial_code_size)
+                 EncDict.empty [ char ] (initial_code_size + 1) (clear_code + 2)
           else
             (code, code_size)
             :: encode

--- a/test/test_gif.ml
+++ b/test/test_gif.ml
@@ -58,16 +58,12 @@ let test_write_image_6_bpp _ =
   let colours = 64 and bpp = 6 in
   let temp_dir = Filename.temp_dir "test" "write" in
   let colour_table = Array.init colours (fun i -> (i, i, i)) in
-  let pixels = List.init (width * height) (fun i -> (Z.of_int (i mod colours), bpp)) in
+  let pixels =
+    List.init (width * height) (fun i -> (Z.of_int (i mod colours), bpp))
+  in
   let packed_pixels = Lzw.flatten_codes 8 pixels in
   let compressed = Lzw.encode packed_pixels bpp in
-  let image = Image.v
-    (width, height)
-    colour_table
-    compressed
-    bpp
-    false
-  in
+  let image = Image.v (width, height) colour_table compressed bpp false in
   let src_gif = GIF.from_image image in
   let filename = temp_dir ^ "/6bpp.gif" in
   GIF.to_file src_gif filename;
@@ -81,16 +77,12 @@ let test_write_image_8_bpp _ =
   let colours = 256 and bpp = 8 in
   let temp_dir = Filename.temp_dir "test" "write" in
   let colour_table = Array.init colours (fun i -> (i, i, i)) in
-  let pixels = List.init (width * height) (fun i -> (Z.of_int (i mod colours), bpp)) in
+  let pixels =
+    List.init (width * height) (fun i -> (Z.of_int (i mod colours), bpp))
+  in
   let packed_pixels = Lzw.flatten_codes 8 pixels in
   let compressed = Lzw.encode packed_pixels bpp in
-  let image = Image.v
-    (width, height)
-    colour_table
-    compressed
-    bpp
-    false
-  in
+  let image = Image.v (width, height) colour_table compressed bpp false in
   let src_gif = GIF.from_image image in
   let filename = temp_dir ^ "/6bpp.gif" in
   GIF.to_file src_gif filename;
@@ -108,6 +100,6 @@ let suite =
          "Test read mono image" >:: test_read_mono_image;
          "Test write 6 bpp image" >:: test_write_image_6_bpp;
          "Test write 8 bpp image" >:: test_write_image_8_bpp;
-        ]
+       ]
 
 let () = run_test_tt_main suite

--- a/test/test_lzw.ml
+++ b/test/test_lzw.ml
@@ -69,8 +69,11 @@ let test_get_longer_slices _ =
   done
 
 let test_encode_decode _ =
-  let src = Lzw.flatten_codes 8 [ (Z.of_int 0xAB, 8); (Z.of_int 0xCD, 8); (Z.of_int 0xEF, 8) ] in
-  [ 8; 6; 4; 3; 2]
+  let src =
+    Lzw.flatten_codes 8
+      [ (Z.of_int 0xAB, 8); (Z.of_int 0xCD, 8); (Z.of_int 0xEF, 8) ]
+  in
+  [ 8; 6; 4; 3; 2 ]
   |> List.iter (fun bpp ->
          let encoded = Lzw.encode src bpp in
          let decoded = Lzw.decode encoded bpp in
@@ -89,14 +92,15 @@ let test_large_encode_decode _ =
   let src = Bytes.init 100000 (fun i -> Char.chr (i land 0xFF)) in
   let encoded = Lzw.encode src 8 in
   let decoded = Lzw.decode encoded 8 in
-  assert_bool "encoded should be smaller than src" ((Bytes.length encoded) < (Bytes.length src));
-  assert_bool "src should be same size as decoded" ((Bytes.length decoded) = (Bytes.length src));
-  for i = 0 to (10000 - 1) do
+  assert_bool "encoded should be smaller than src"
+    (Bytes.length encoded < Bytes.length src);
+  assert_bool "src should be same size as decoded"
+    (Bytes.length decoded = Bytes.length src);
+  for i = 0 to 10000 - 1 do
     let expected = int_of_char (Bytes.get src i)
     and actual = int_of_char (Bytes.get decoded i) in
     assert_equal ~msg:"data" ~printer:string_of_int expected actual
   done
-
 
 let suite =
   "LZW"


### PR DESCRIPTION
Fixes #10 

- The version is updated to the latest one 0.27.0 
- Formatting is applied
