### PR TITLE
Fix bug with global colour table size

### DIFF
--- a/giflib/gIF.ml
+++ b/giflib/gIF.ml
@@ -498,7 +498,7 @@ let from_image img =
   (* minimalny rozmiar kodu to 2 *)
   let code_size = if ct_size < 2 then 2 else ct_size + 1 in
   let new_palette =
-    let p = ColorTable.create (2 lsl (ct_size + 1)) in
+    let p = ColorTable.create (1 lsl (ct_size + 1)) in
     Array.iteri (fun n c -> ColorTable.set p n c) palette;
     p
   in

--- a/test/test_gif.ml
+++ b/test/test_gif.ml
@@ -68,9 +68,19 @@ let test_write_image_6_bpp _ =
   let filename = temp_dir ^ "/6bpp.gif" in
   GIF.to_file src_gif filename;
 
+  let img = GIF.get_image src_gif 0 in
+  let palette = Image.palette img in
+  assert_equal ~msg:"palette size" ~printer:string_of_int colours
+    (ColorTable.size palette);
+
   let dst_gif = GIF.from_file filename in
   assert_equal 1 (GIF.image_count dst_gif);
-  assert_equal ~msg:"screen dims" (width, height) (GIF.dimensions dst_gif)
+  assert_equal ~msg:"screen dims" (width, height) (GIF.dimensions dst_gif);
+
+  let img = GIF.get_image dst_gif 0 in
+  let palette = Image.palette img in
+  assert_equal ~msg:"palette size" ~printer:string_of_int colours
+    (ColorTable.size palette)
 
 let test_write_image_8_bpp _ =
   let width = 100 and height = 100 in
@@ -87,9 +97,19 @@ let test_write_image_8_bpp _ =
   let filename = temp_dir ^ "/6bpp.gif" in
   GIF.to_file src_gif filename;
 
+  let img = GIF.get_image src_gif 0 in
+  let palette = Image.palette img in
+  assert_equal ~msg:"palette size" ~printer:string_of_int colours
+    (ColorTable.size palette);
+
   let dst_gif = GIF.from_file filename in
   assert_equal 1 (GIF.image_count dst_gif);
-  assert_equal ~msg:"screen dims" (width, height) (GIF.dimensions dst_gif)
+  assert_equal ~msg:"screen dims" (width, height) (GIF.dimensions dst_gif);
+
+  let img = GIF.get_image dst_gif 0 in
+  let palette = Image.palette img in
+  assert_equal ~msg:"palette size" ~printer:string_of_int colours
+    (ColorTable.size palette)
 
 let suite =
   "BasicLoading"


### PR DESCRIPTION
This fixes a bug whereby GIFs would not open on macOS in the default preview app #9 

The bug was that there was a logic error when creating the global colour table in the GIF library, and it'd create it twice as large as necessary, but all the header information still said it was the expected size. This lead to there being a block of zeros the size of the palette (the uninitialised top half of the extra large table). It seems most GIF viewers ignore this, which is why other image viewers worked, but technically it was wrong to have that empty space in the file, and it is a waste of disk space!

This PR adds tests that catch the error and fixes in.