### PR TITLE
[Feat]: adding from_images to giflib

### DIFF
--- a/giflib/gIF.ml
+++ b/giflib/gIF.ml
@@ -588,6 +588,39 @@ let from_images (images : Image.t list) : t =
         }
       in
 
+      let blocks =
+        List.map
+          (fun img ->
+            let ctl =
+              {
+                disposal_method = 0;
+                user_input = false;
+                transparent_color = Image.transparent img;
+                delay_time =
+                  (match Image.delay_time img with Some d -> d | None -> 0);
+              }
+            in
+            let desc =
+              {
+                image_left_pos = 0;
+                image_top_pos = 0;
+                image_width = w;
+                image_height = h;
+                local_color_table = None;
+                local_color_table_sort = false;
+                local_color_table_size = 0;
+                interlace_flag = false ;
+              }
+            in
+            ImageBlock
+              {
+                image_descriptor = desc;
+                image_control = Some ctl;
+                image_data = Image.compressed_image_data img;
+                image_lzw_code_size = code_size;
+              })
+          images
+      in
       { stream_descriptor = info; blocks }
 
 let dimensions i =

--- a/giflib/gIF.ml
+++ b/giflib/gIF.ml
@@ -558,8 +558,25 @@ let from_images (images : Image.t list) : t =
             raise (Error "from_images: too many colors in an image"))
         images;
 
-      
-
+      let palette = Image.palette img0 in
+      let ct_size =
+        let n = Array.length palette in
+        if n <= 2 then 0
+        else if n <= 4 then 1
+        else if n <= 8 then 2
+        else if n <= 16 then 3
+        else if n <= 32 then 4
+        else if n <= 64 then 5
+        else if n <= 128 then 6
+        else if n <= 256 then 7
+        else raise (Error "from_images: too many colors")
+      in
+      let code_size = if ct_size < 2 then 2 else ct_size + 1 in
+      let global_ct =
+        let p = ColorTable.create (1 lsl (ct_size + 1)) in
+        Array.iteri (fun i c -> ColorTable.set p i c) palette;
+        p
+      in
 
       { stream_descriptor = info; blocks }
 

--- a/giflib/gIF.ml
+++ b/giflib/gIF.ml
@@ -578,6 +578,16 @@ let from_images (images : Image.t list) : t =
         p
       in
 
+      let info =
+        {
+          default_info with
+          screen_width = w;
+          screen_height = h;
+          global_color_table = Some global_ct;
+          global_color_table_size = ct_size;
+        }
+      in
+
       { stream_descriptor = info; blocks }
 
 let dimensions i =

--- a/giflib/gIF.ml
+++ b/giflib/gIF.ml
@@ -543,5 +543,25 @@ let from_image img =
   in
   { stream_descriptor = info; blocks }
 
+let from_images (images : Image.t list) : t =
+  match images with
+  | [] -> raise (Error "from_images: empty image list")
+  | img0 :: _ ->
+      let w, h = Image.dimensions img0 in
+      List.iter
+        (fun img ->
+          let w', h' = Image.dimensions img in
+          if w <> w' || h <> h' then
+            raise (Error "from_images: inconsistent image dimensions");
+          let n_colors = Array.length (Image.palette img) in
+          if n_colors > 256 then
+            raise (Error "from_images: too many colors in an image"))
+        images;
+
+      
+
+
+      { stream_descriptor = info; blocks }
+
 let dimensions i =
   (i.stream_descriptor.screen_width, i.stream_descriptor.screen_height)


### PR DESCRIPTION
Fixes #15 

Currently I have only added the from_images to giflib. 

This initial version of the PR primarily checks for the dimensions of all the images to be consistent. The shared logic between from_image and from_images is yet to be implemented. 