### PR TITLE
Use dune to move test data into place

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -1,3 +1,5 @@
 (tests
  (names test_gif test_lzw)
+ (deps
+  (source_tree testdata))
  (libraries giflib ounit2))

--- a/test/test_gif.ml
+++ b/test/test_gif.ml
@@ -2,7 +2,7 @@ open OUnit2
 open Giflib
 
 let test_example_file _ =
-  let g = GIF.from_file "../../../test/testdata/test1.gif" in
+  let g = GIF.from_file "testdata/test1.gif" in
   assert_equal ~msg:"image count" 1 (GIF.image_count g);
   assert_equal ~msg:"screen dims" (16, 16) (GIF.dimensions g);
   let i = GIF.get_image g 0 in
@@ -27,12 +27,12 @@ let test_example_file _ =
   assert_equal ~msg:"orange pixel" (255, 118, 17) (ColorTable.get palette 0)
 
 let test_get_image_fail _ =
-  let g = GIF.from_file "../../../test/testdata/test1.gif" in
+  let g = GIF.from_file "testdata/test1.gif" in
   assert_raises (GIF.Error "get_image: frame not found") (fun () ->
       GIF.get_image g 1)
 
 let test_read_image_twice _ =
-  let g = GIF.from_file "../../../test/testdata/test1.gif" in
+  let g = GIF.from_file "testdata/test1.gif" in
   let _ = GIF.get_image g 0 in
   let i = GIF.get_image g 0 in
   let w, h = Image.dimensions i in
@@ -42,7 +42,7 @@ let test_read_image_twice _ =
   assert_equal (ColorTable.size (Image.palette i)) 4
 
 let test_read_mono_image _ =
-  let g = GIF.from_file "../../../test/testdata/flitter.gif" in
+  let g = GIF.from_file "testdata/flitter.gif" in
   assert_equal 1 (GIF.image_count g);
   assert_equal ~msg:"screen dims" (640, 480) (GIF.dimensions g);
   let i = GIF.get_image g 0 in


### PR DESCRIPTION
Fixes #21 

This should be a better way to access test data - rather than skipping outside of the _build environment where the tests are run, actually use dune to place the data in the place the tests are.