### PR TITLE
camlp-streams removed from dune

### DIFF
--- a/giflib/dune
+++ b/giflib/dune
@@ -1,4 +1,4 @@
 (library
  (public_name giflib)
  (name giflib)
- (libraries camlp-streams zarith))
+ (libraries zarith))


### PR DESCRIPTION
camlp-streams is no longer a dependency and hence removed from dune 

