### PR TITLE
Flags modification

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
 
-      - run: opam install . --deps-only --with-test
+      - run: opam install . --deps-only --with-test --with-doc --with-dev-setup
 
       - run: opam exec -- dune build
 

--- a/dune-project
+++ b/dune-project
@@ -19,6 +19,6 @@
  (name giflib)
  (synopsis "Implementation of GIF image format in OCaml")
  (description "Implementation of GIF image format in OCaml.")
- (depends (ocaml (>= 5.1)) dune ounit2 zarith odoc (ocamlformat (>= 0.27.0)))
+ (depends (ocaml (>= 5.1)) dune (ounit2 :with-test) zarith (odoc :with-doc) (ocamlformat (and (>= 0.27.0) :with-dev-setup)))
  (tags
   (image gif bitmap)))

--- a/giflib.opam
+++ b/giflib.opam
@@ -19,10 +19,10 @@ bug-reports: "https://github.com/claudiusFX/ocaml-gif/issues"
 depends: [
   "ocaml" {>= "5.1"}
   "dune" {>= "3.14"}
-  "ounit2"
+  "ounit2" {with-test}
   "zarith"
-  "odoc"
-  "ocamlformat" {>= "0.27.0"}
+  "odoc" {with-doc}
+  "ocamlformat" {>= "0.27.0" & with-dev-setup}
 ]
 build: [
   ["dune" "subst"] {dev}


### PR DESCRIPTION
The flags were originally added to opam manually. Now they are being added to dune-project so as to auto generate them in the opam file on every dune build.

Flags added: {with-dev-setup}, {with-doc}, {with-test}