### PR TITLE
Simplify image creation

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,4 +1,4 @@
-(lang dune 3.14)
+(lang dune 3.18)
 
 (name giflib)
 
@@ -12,6 +12,8 @@
 (maintainers "Michael Dales <michael@digitalflapjack.com>" "Shreya Pawaskar <shreya.pawaskar.main@gmail.com>")
 
 (license MIT)
+
+(maintenance_intent "(latest)")
 
 (documentation https://github.com/claudiusFX/ocaml-gif)
 

--- a/giflib.opam
+++ b/giflib.opam
@@ -18,7 +18,7 @@ doc: "https://github.com/claudiusFX/ocaml-gif"
 bug-reports: "https://github.com/claudiusFX/ocaml-gif/issues"
 depends: [
   "ocaml" {>= "5.1"}
-  "dune" {>= "3.14"}
+  "dune" {>= "3.18"}
   "ounit2" {with-test}
   "zarith"
   "odoc" {with-doc}
@@ -39,3 +39,4 @@ build: [
   ]
 ]
 dev-repo: "git+https://github.com/claudiusFX/ocaml-gif.git"
+x-maintenance-intent: ["(latest)"]

--- a/giflib/image.mli
+++ b/giflib/image.mli
@@ -14,6 +14,19 @@ val v :
   int ->
   bool ->
   t
+(** [v ?offset ?transparent ?delay_time dim palette compressed_image_data
+     lzw_code_size interlaced] Create an image record for use inside a GIF.t. *)
+
+val of_pixels :
+  ?offset:int * int ->
+  ?transparent:int option ->
+  ?delay_time:int option ->
+  int * int ->
+  ColorTable.t ->
+  int array ->
+  t
+(** [of_pixels ?offset ?transparency ?delay_time dimensions palette pixels]
+    Creates a new image record from a set of pixel data and a palette. *)
 
 val dimensions : t -> int * int
 (** The dimensions of the image. Note that this might be smaller than the

--- a/test/dune
+++ b/test/dune
@@ -1,5 +1,5 @@
 (tests
- (names test_gif test_lzw)
+ (names test_gif test_lzw test_image)
  (deps
   (source_tree testdata))
  (libraries giflib ounit2))

--- a/test/test_gif.ml
+++ b/test/test_gif.ml
@@ -82,6 +82,31 @@ let test_write_image_6_bpp _ =
   assert_equal ~msg:"palette size" ~printer:string_of_int colours
     (ColorTable.size palette)
 
+let test_write_image_of_pixels_6_bpp _ =
+  let width = 100 and height = 100 in
+  let colours = 64 in
+  let temp_dir = Filename.temp_dir "test" "write" in
+  let colour_table = Array.init colours (fun i -> (i, i, i)) in
+  let pixels = Array.init (width * height) (fun i -> i mod colours) in
+  let image = Image.of_pixels (width, height) colour_table pixels in
+  let src_gif = GIF.from_image image in
+  let filename = temp_dir ^ "/6bpp.gif" in
+  GIF.to_file src_gif filename;
+
+  let img = GIF.get_image src_gif 0 in
+  let palette = Image.palette img in
+  assert_equal ~msg:"palette size" ~printer:string_of_int colours
+    (ColorTable.size palette);
+
+  let dst_gif = GIF.from_file filename in
+  assert_equal 1 (GIF.image_count dst_gif);
+  assert_equal ~msg:"screen dims" (width, height) (GIF.dimensions dst_gif);
+
+  let img = GIF.get_image dst_gif 0 in
+  let palette = Image.palette img in
+  assert_equal ~msg:"palette size" ~printer:string_of_int colours
+    (ColorTable.size palette)
+
 let test_write_image_8_bpp _ =
   let width = 100 and height = 100 in
   let colours = 256 and bpp = 8 in
@@ -109,6 +134,57 @@ let test_write_image_8_bpp _ =
   let img = GIF.get_image dst_gif 0 in
   let palette = Image.palette img in
   assert_equal ~msg:"palette size" ~printer:string_of_int colours
+    (ColorTable.size palette)
+
+let test_write_image_of_pixels_8_bpp _ =
+  let width = 100 and height = 100 in
+  let colours = 256 in
+  let temp_dir = Filename.temp_dir "test" "write" in
+  let colour_table = Array.init colours (fun i -> (i, i, i)) in
+  let pixels = Array.init (width * height) (fun i -> i mod colours) in
+  let image = Image.of_pixels (width, height) colour_table pixels in
+  let src_gif = GIF.from_image image in
+  let filename = temp_dir ^ "/6bpp.gif" in
+  GIF.to_file src_gif filename;
+
+  let img = GIF.get_image src_gif 0 in
+  let palette = Image.palette img in
+  assert_equal ~msg:"palette size" ~printer:string_of_int colours
+    (ColorTable.size palette);
+
+  let dst_gif = GIF.from_file filename in
+  assert_equal 1 (GIF.image_count dst_gif);
+  assert_equal ~msg:"screen dims" (width, height) (GIF.dimensions dst_gif);
+
+  let img = GIF.get_image dst_gif 0 in
+  let palette = Image.palette img in
+  assert_equal ~msg:"palette size" ~printer:string_of_int colours
+    (ColorTable.size palette)
+
+let test_write_image_non_power_2_colors _ =
+  let width = 100 and height = 100 in
+  let colours = 20 in
+  let temp_dir = Filename.temp_dir "test" "write" in
+  let colour_table = Array.init colours (fun i -> (i, i, i)) in
+  let pixels = Array.init (width * height) (fun i -> i mod colours) in
+  let image = Image.of_pixels (width, height) colour_table pixels in
+  let src_gif = GIF.from_image image in
+  let filename = temp_dir ^ "/6bpp.gif" in
+  GIF.to_file src_gif filename;
+
+  let img = GIF.get_image src_gif 0 in
+  let palette = Image.palette img in
+  let expected_colors = 32 in
+  assert_equal ~msg:"palette size" ~printer:string_of_int expected_colors
+    (ColorTable.size palette);
+
+  let dst_gif = GIF.from_file filename in
+  assert_equal 1 (GIF.image_count dst_gif);
+  assert_equal ~msg:"screen dims" (width, height) (GIF.dimensions dst_gif);
+
+  let img = GIF.get_image dst_gif 0 in
+  let palette = Image.palette img in
+  assert_equal ~msg:"palette size" ~printer:string_of_int expected_colors
     (ColorTable.size palette)
 
 let test_write_animation_8_bpp _ =
@@ -163,7 +239,12 @@ let suite =
          "Test re-read image" >:: test_read_image_twice;
          "Test read mono image" >:: test_read_mono_image;
          "Test write 6 bpp image" >:: test_write_image_6_bpp;
+         "Test write 6 bpp image using of_pixels"
+         >:: test_write_image_of_pixels_6_bpp;
          "Test write 8 bpp image" >:: test_write_image_8_bpp;
+         "Test write 8 bpp image using of_pixels"
+         >:: test_write_image_of_pixels_8_bpp;
+         "Test write 20 color image" >:: test_write_image_non_power_2_colors;
          "Test write 8 bpp animation" >:: test_write_animation_8_bpp;
        ]
 

--- a/test/test_image.ml
+++ b/test/test_image.ml
@@ -1,0 +1,34 @@
+open OUnit2
+open Giflib
+
+let test_image_too_few_colors _ =
+  let width = 100 and height = 100 in
+  let colour_table = [||] in
+  let pixels = Array.init (width * height) (fun _ -> 0) in
+  assert_raises (Invalid_argument "Palette has no entries") (fun () ->
+      Image.of_pixels (width, height) colour_table pixels)
+
+let test_image_too_many_colors _ =
+  let width = 100 and height = 100 in
+  let colour_table = Array.init 257 (fun i -> (i, i, i)) in
+  let pixels = Array.init (width * height) (fun _ -> 0) in
+  assert_raises (Invalid_argument "Palette larger than 256 entries") (fun () ->
+      Image.of_pixels (width, height) colour_table pixels)
+
+let test_dimensions_wrong _ =
+  let width = 100 and height = 100 in
+  let colour_table = Array.init 32 (fun i -> (i, i, i)) in
+  let pixels = Array.init (width * height) (fun _ -> 0) in
+  assert_raises
+    (Invalid_argument "Dimensions and pixel array have different size")
+    (fun () -> Image.of_pixels (width + 1, height + 1) colour_table pixels)
+
+let suite =
+  "Image.t tests"
+  >::: [
+         "Test too few colors" >:: test_image_too_few_colors;
+         "Test too many colors" >:: test_image_too_many_colors;
+         "Test dimensions are wrong" >:: test_dimensions_wrong;
+       ]
+
+let () = run_test_tt_main suite


### PR DESCRIPTION
This PR adds an Image.of_pixel function that is designed to make life easier for the user of this library in creating new images without having to expose the LZW compression or internal storage styles of the library. For example, see how much GIF library internals are exposed here: https://github.com/claudiusFX/Claudius/blob/1.1.1/src/utils_gif.ml

